### PR TITLE
feat: display cta dot on project updates tab

### DIFF
--- a/src/components/Layout/Navigation.css
+++ b/src/components/Layout/Navigation.css
@@ -10,7 +10,7 @@
   list-style-type: none;
 }
 
-.Navigation .dcl.tab svg {
+.dcl.tab svg {
   margin-left: 4px;
   vertical-align: middle;
 }

--- a/src/components/Layout/Navigation.css
+++ b/src/components/Layout/Navigation.css
@@ -10,11 +10,6 @@
   list-style-type: none;
 }
 
-.dcl.tab svg {
-  margin-left: 4px;
-  vertical-align: middle;
-}
-
 .dcl.navbar-account .ui.button.inverted {
   color: black;
   border: 1px solid black;

--- a/src/components/Projects/ProjectView.tsx
+++ b/src/components/Projects/ProjectView.tsx
@@ -3,9 +3,11 @@ import { useMemo, useState } from 'react'
 import classNames from 'classnames'
 
 import useFormatMessage from '../../hooks/useFormatMessage'
+import useShowProjectUpdatesCta from '../../hooks/useShowProjectUpdatesCta.ts'
 import { ProjectStatus } from '../../types/grants.ts'
 import { Project } from '../../types/proposals'
 import BoxTabs from '../Common/BoxTabs'
+import Dot from '../Icon/Dot.tsx'
 
 import UpdatesTabView from './Updates/UpdatesTabView'
 
@@ -28,7 +30,9 @@ function ProjectView({ project, onClose, isFullscreen = false }: Props) {
     (!project.milestones || project.milestones.length === 0)
   )
 
-  const MENU_ITEMS: { labelKey: string; view: React.ReactNode }[] = useMemo(() => {
+  const { showUpdatesCta } = useShowProjectUpdatesCta(project)
+
+  const MENU_ITEMS: { labelKey: string; view: React.ReactNode; showDot?: boolean }[] = useMemo(() => {
     return [
       {
         labelKey: 'page.project_sidebar.general_info.title',
@@ -45,9 +49,10 @@ function ProjectView({ project, onClose, isFullscreen = false }: Props) {
       {
         labelKey: 'page.project_sidebar.updates.title',
         view: <UpdatesTabView project={project} />,
+        showDot: showUpdatesCta,
       },
     ]
-  }, [project, showMilestonesTab])
+  }, [project, showMilestonesTab, showUpdatesCta])
   return (
     <div>
       {project && <ProjectSheetTitle project={project} onClose={onClose} isFullscreen={isFullscreen} />}
@@ -57,6 +62,7 @@ function ProjectView({ project, onClose, isFullscreen = false }: Props) {
           {MENU_ITEMS.map((item, idx) => (
             <BoxTabs.Tab key={idx} active={idx === viewIdx} onClick={() => setViewIdx(idx)}>
               {t(item.labelKey)}
+              {!!item.showDot && <Dot />}
             </BoxTabs.Tab>
           ))}
         </BoxTabs.Left>

--- a/src/hooks/useProjectUpdates.ts
+++ b/src/hooks/useProjectUpdates.ts
@@ -1,7 +1,11 @@
+import { useMemo } from 'react'
+
 import { useQuery } from '@tanstack/react-query'
 
 import { Governance } from '../clients/Governance'
 import { UpdateResponse } from '../types/updates'
+import Time from '../utils/date/Time.ts'
+import { isBetweenLateThresholdDate } from '../utils/updates.ts'
 
 import { DEFAULT_QUERY_STALE_TIME } from './constants'
 
@@ -22,14 +26,37 @@ export default function useProjectUpdates(projectId?: string | null) {
     staleTime: DEFAULT_QUERY_STALE_TIME,
   })
 
+  const publicUpdates = updates?.publicUpdates || []
+  const pendingUpdates = updates?.pendingUpdates
+  const nextUpdate = updates?.nextUpdate
+  const hasUpdates = publicUpdates.length > 0
+  const currentUpdate = updates?.currentUpdate
+  const hasSubmittedUpdate = !!currentUpdate?.completion_date
+  const hasPendingMandatoryUpdate = !!currentUpdate && !currentUpdate.completion_date
+  const nextDueDateRemainingDays = Time(nextUpdate?.due_date).diff(new Date(), 'days')
+
+  const latePendingUpdate = useMemo(
+    () =>
+      pendingUpdates?.find(
+        (update) =>
+          update.id !== nextUpdate?.id && Time().isAfter(update.due_date) && isBetweenLateThresholdDate(update.due_date)
+      ),
+    [nextUpdate?.id, pendingUpdates]
+  )
+
   return {
-    publicUpdates: updates?.publicUpdates,
-    pendingUpdates: updates?.pendingUpdates,
-    nextUpdate: updates?.nextUpdate,
-    currentUpdate: updates?.currentUpdate,
+    publicUpdates,
+    pendingUpdates: pendingUpdates || [],
+    nextUpdate,
+    currentUpdate,
     isLoading,
     isError,
     refetchUpdates: refetch,
     latestPublishedUpdate: updates?.publicUpdates?.find((item) => !!item.completion_date),
+    latePendingUpdate,
+    hasUpdates,
+    hasSubmittedUpdate,
+    nextDueDateRemainingDays,
+    hasPendingMandatoryUpdate,
   }
 }

--- a/src/hooks/useShowProjectUpdatesCta.ts
+++ b/src/hooks/useShowProjectUpdatesCta.ts
@@ -4,6 +4,8 @@ import { Project } from '../types/proposals.ts'
 import useIsProjectEditor from './useIsProjectEditor.ts'
 import useProjectUpdates from './useProjectUpdates.ts'
 
+const UPDATED_CTA_FEATURE_RELEASE_DATE = new Date('2023-06-26')
+
 function getStoredDate(key: string): Date | null {
   const dateString = localStorage.getItem(key)
   if (dateString && dateString.length > 0) {
@@ -18,18 +20,16 @@ function getStoredDate(key: string): Date | null {
 export default function useShowProjectUpdatesCta(project?: Project | null) {
   const { isEditor } = useIsProjectEditor(project)
   const { hasPendingMandatoryUpdate, latestPublishedUpdate } = useProjectUpdates(project?.id)
-
+  const now = new Date()
   const savedDate = getStoredDate(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
-  console.log('savedDate', savedDate)
   const latestCheckToUpdatesTab = savedDate ? new Date(savedDate) : null
   const editorHasPendingMandatoryUpdates = isEditor && hasPendingMandatoryUpdate
   const newUpdateForNonEditors =
     !isEditor &&
     latestPublishedUpdate &&
     ((latestCheckToUpdatesTab && latestPublishedUpdate.updated_at > latestCheckToUpdatesTab) ||
-      latestCheckToUpdatesTab === null)
+      latestCheckToUpdatesTab === null) &&
+    now > UPDATED_CTA_FEATURE_RELEASE_DATE
 
-  console.log('editorHasPendingMandatoryUpdates', editorHasPendingMandatoryUpdates)
-  console.log('newUpdateForNonEditors', newUpdateForNonEditors)
   return { showUpdatesCta: editorHasPendingMandatoryUpdates || newUpdateForNonEditors }
 }

--- a/src/hooks/useShowProjectUpdatesCta.ts
+++ b/src/hooks/useShowProjectUpdatesCta.ts
@@ -26,7 +26,7 @@ export default function useShowProjectUpdatesCta(project?: Project | null) {
   const editorHasPendingMandatoryUpdates = isEditor && hasPendingMandatoryUpdate
   const newUpdateForNonEditors =
     !isEditor &&
-    latestPublishedUpdate &&
+    !!latestPublishedUpdate &&
     ((latestCheckToUpdatesTab && latestPublishedUpdate.updated_at > latestCheckToUpdatesTab) ||
       latestCheckToUpdatesTab === null) &&
     now > UPDATED_CTA_FEATURE_RELEASE_DATE

--- a/src/hooks/useShowProjectUpdatesCta.ts
+++ b/src/hooks/useShowProjectUpdatesCta.ts
@@ -21,8 +21,7 @@ export default function useShowProjectUpdatesCta(project?: Project | null) {
   const { isEditor } = useIsProjectEditor(project)
   const { hasPendingMandatoryUpdate, latestPublishedUpdate } = useProjectUpdates(project?.id)
   const now = new Date()
-  const savedDate = getStoredDate(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
-  const latestCheckToUpdatesTab = savedDate ? new Date(savedDate) : null
+  const latestCheckToUpdatesTab = getStoredDate(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
   const editorHasPendingMandatoryUpdates = isEditor && hasPendingMandatoryUpdate
   const newUpdateForNonEditors =
     !isEditor &&

--- a/src/hooks/useShowProjectUpdatesCta.ts
+++ b/src/hooks/useShowProjectUpdatesCta.ts
@@ -1,17 +1,18 @@
 import { PROJECT_UPDATES_LATEST_CHECK } from '../localStorageKeys.ts'
 import { Project } from '../types/proposals.ts'
+import Time from '../utils/date/Time.ts'
 
 import useIsProjectEditor from './useIsProjectEditor.ts'
 import useProjectUpdates from './useProjectUpdates.ts'
 
-const UPDATED_CTA_FEATURE_RELEASE_DATE = new Date('2023-06-26')
+const UPDATED_CTA_FEATURE_RELEASE_DATE = Time('2024-06-25T00:00:00Z')
 
-function getStoredDate(key: string): Date | null {
+function getStoredTime(key: string): Time.Dayjs | null {
   const dateString = localStorage.getItem(key)
   if (dateString && dateString.length > 0) {
-    const date = new Date(dateString)
-    if (!isNaN(date.getTime())) {
-      return date
+    const time = Time(dateString)
+    if (time.isValid()) {
+      return time
     }
   }
   return null
@@ -20,15 +21,13 @@ function getStoredDate(key: string): Date | null {
 export default function useShowProjectUpdatesCta(project?: Project | null) {
   const { isEditor } = useIsProjectEditor(project)
   const { hasPendingMandatoryUpdate, latestPublishedUpdate } = useProjectUpdates(project?.id)
-  const now = new Date()
-  const latestCheckToUpdatesTab = getStoredDate(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
+  const latestCheckToUpdatesTab = getStoredTime(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
   const editorHasPendingMandatoryUpdates = isEditor && hasPendingMandatoryUpdate
   const newUpdateForNonEditors =
     !isEditor &&
     !!latestPublishedUpdate &&
-    ((latestCheckToUpdatesTab && latestPublishedUpdate.updated_at > latestCheckToUpdatesTab) ||
-      latestCheckToUpdatesTab === null) &&
-    now > UPDATED_CTA_FEATURE_RELEASE_DATE
+    ((!!latestCheckToUpdatesTab && latestCheckToUpdatesTab.isBefore(latestPublishedUpdate.updated_at)) ||
+      (latestCheckToUpdatesTab === null && UPDATED_CTA_FEATURE_RELEASE_DATE.isBefore(latestPublishedUpdate.updated_at)))
 
   return { showUpdatesCta: editorHasPendingMandatoryUpdates || newUpdateForNonEditors }
 }

--- a/src/hooks/useShowProjectUpdatesCta.ts
+++ b/src/hooks/useShowProjectUpdatesCta.ts
@@ -1,0 +1,35 @@
+import { PROJECT_UPDATES_LATEST_CHECK } from '../localStorageKeys.ts'
+import { Project } from '../types/proposals.ts'
+
+import useIsProjectEditor from './useIsProjectEditor.ts'
+import useProjectUpdates from './useProjectUpdates.ts'
+
+function getStoredDate(key: string): Date | null {
+  const dateString = localStorage.getItem(key)
+  if (dateString && dateString.length > 0) {
+    const date = new Date(dateString)
+    if (!isNaN(date.getTime())) {
+      return date
+    }
+  }
+  return null
+}
+
+export default function useShowProjectUpdatesCta(project?: Project | null) {
+  const { isEditor } = useIsProjectEditor(project)
+  const { hasPendingMandatoryUpdate, latestPublishedUpdate } = useProjectUpdates(project?.id)
+
+  const savedDate = getStoredDate(`${PROJECT_UPDATES_LATEST_CHECK}-${project?.id}`)
+  console.log('savedDate', savedDate)
+  const latestCheckToUpdatesTab = savedDate ? new Date(savedDate) : null
+  const editorHasPendingMandatoryUpdates = isEditor && hasPendingMandatoryUpdate
+  const newUpdateForNonEditors =
+    !isEditor &&
+    latestPublishedUpdate &&
+    ((latestCheckToUpdatesTab && latestPublishedUpdate.updated_at > latestCheckToUpdatesTab) ||
+      latestCheckToUpdatesTab === null)
+
+  console.log('editorHasPendingMandatoryUpdates', editorHasPendingMandatoryUpdates)
+  console.log('newUpdateForNonEditors', newUpdateForNonEditors)
+  return { showUpdatesCta: editorHasPendingMandatoryUpdates || newUpdateForNonEditors }
+}

--- a/src/localStorageKeys.ts
+++ b/src/localStorageKeys.ts
@@ -1,7 +1,6 @@
 export const HIDE_HOME_BANNER_KEY = 'org.decentraland.governance.home_banner.hide'
 export const HIDE_PROJECTS_BANNER_KEY = 'org.decentraland.governance.projects_banner.hide'
 export const HIDE_DELEGATE_BANNER_KEY = 'org.decentraland.governance.delegate_banner.hide'
-export const HIDE_LINK_DISCORD_BANNER_KEY = 'org.decentraland.governance.link_discord_banner.hide'
 export const SHOW_DISCORD_MODAL_KEY = 'org.decentraland.governance.link_discord_modal.show_data'
 export const HIDE_CONNECT_ACCOUNTS_BANNER_KEY = 'org.decentraland.governance.connect_accounts_banner.hide'
 export const ACTION_BOX_EXPANDED_STATE_KEY = 'org.decentraland.governance.action_box.expanded'
@@ -11,3 +10,4 @@ export const ANONYMOUS_USR_SUBSCRIPTION = 'anonymous_subscription'
 export const HIDE_NEWSLETTER_SUBSCRIPTION_KEY = 'org.decentraland.governance.newsletter_subscription.hide'
 export const NOTIFICATIONS_NEW_FEATURE_DISMISSED_LOCAL_STORAGE_KEY =
   'org.decentraland.governance.notifications-new-feature-dismissed'
+export const PROJECT_UPDATES_LATEST_CHECK = 'org.decentraland.governance.projects.updates.latest_check'

--- a/src/ui-overrides.css
+++ b/src/ui-overrides.css
@@ -209,3 +209,8 @@
 .ui .dcl.back {
   margin: 0 !important;
 }
+
+.dcl.tab svg {
+  margin-left: 4px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Closes [this](https://github.com/orgs/decentraland/projects/24/views/1?pane=issue&itemId=68563850)

Todo: 
- [x] finish testing and remove console logs
- [x] add date limit for displaying red dot only for new updates

If user is editor, they see the dot until an update is published
<img width="852" alt="image" src="https://github.com/decentraland/governance-ui/assets/2858950/9dc0cdf7-354c-4cc3-99aa-49382cf466df">

After posting update
<img width="638" alt="image" src="https://github.com/decentraland/governance-ui/assets/2858950/89f9e07b-b1a6-4c3f-8da2-66af9e602477">

If user is not an editor, they see the dot until they visit the updates tab

<img width="1121" alt="image" src="https://github.com/decentraland/governance-ui/assets/2858950/63bafdd9-c796-41c3-8306-d093968e5938">

After visiting updates tab
<img width="1172" alt="image" src="https://github.com/decentraland/governance-ui/assets/2858950/110603ca-d5e7-472f-bdd1-7c364827a7b3">
