### PR TITLE
fix: remove unused sections

### DIFF
--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -17,14 +17,11 @@ import LoadingView from '../components/Layout/LoadingView'
 import Navigation, { NavigationTab } from '../components/Layout/Navigation'
 import TokenBalanceCard from '../components/Token/TokenBalanceCard'
 import BudgetCard from '../components/Transparency/BudgetCard'
-import CoreUnitsSection from '../components/Transparency/CoreUnitsSection'
 import DaoVestingCard from '../components/Transparency/DaoVestingCard'
 import GrantList from '../components/Transparency/GrantList'
-import MembersSection from '../components/Transparency/MembersSection'
 import MonthlyTotal from '../components/Transparency/MonthlyTotal'
 import Sidebar from '../components/Transparency/Sidebar'
 import { DOCS_URL, JOIN_DISCORD_URL, OPEN_CALL_FOR_DELEGATES_LINK } from '../constants'
-import useCoreUnitsBadges from '../hooks/useCoreUnitsBadges'
 import useFormatMessage from '../hooks/useFormatMessage'
 import useTransparency from '../hooks/useTransparency'
 import { ProposalStatus } from '../types/proposals'
@@ -44,7 +41,6 @@ export default function TransparencyPage() {
   const t = useFormatMessage()
   const { data } = useTransparency()
   const balances = useMemo(() => (data && aggregateBalances(data.balances)) || [], [data])
-  const { coreUnitsBadges } = useCoreUnitsBadges()
 
   return (
     <>
@@ -181,37 +177,7 @@ export default function TransparencyPage() {
                   },
                 ]}
               />
-
-              <div className="Transparency__Section">
-                <Card className="Transparency__Card">
-                  {data &&
-                    data.committees.map((team, index) => {
-                      return (
-                        <MembersSection
-                          key={[team.name.trim(), index].join('::')}
-                          title={team.name}
-                          description={team.description}
-                          members={team.members}
-                        />
-                      )
-                    })}
-                </Card>
-              </div>
             </div>
-
-            {coreUnitsBadges && (
-              <div className="TransparencyGrid">
-                <Sidebar
-                  title={t('page.transparency.core_units.title')}
-                  description={t('page.transparency.core_units.description')}
-                />
-                <div className="Transparency__Section">
-                  <Card className="Transparency__Card">
-                    <CoreUnitsSection coreUnitsBadges={coreUnitsBadges} />
-                  </Card>
-                </div>
-              </div>
-            )}
           </WiderContainer>
         )}
       </div>


### PR DESCRIPTION
Related issue #200 

1. In this Pr you can find:

-Remove "Core Units" section
-Remove "Revocation committee" section

2. Screenshots:

-Before

<img width="1430" height="500" alt="Captura de pantalla 2025-10-02 a la(s) 9 02 50 a  m" src="https://github.com/user-attachments/assets/3e27460c-5466-45e2-9da7-98dc9044254e" />

-After

<img width="1470" height="433" alt="Captura de pantalla 2025-10-02 a la(s) 9 03 00 a  m" src="https://github.com/user-attachments/assets/ab56b85e-5d0a-4d8f-a7fa-d9c6ea5b7825" />

