### PR TITLE
fix: remove grant program budget card

### DIFF
--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 
 import { Card } from 'decentraland-ui/dist/components/Card/Card'
-import { Header } from 'decentraland-ui/dist/components/Header/Header'
 
 import Heading from '../components/Common/Typography/Heading'
 import WiderContainer from '../components/Common/WiderContainer'
@@ -10,26 +9,18 @@ import Database from '../components/Icon/Database'
 import Discord from '../components/Icon/Discord'
 import Document from '../components/Icon/Document'
 import DocumentOutline from '../components/Icon/DocumentOutline'
-import OpenFolder from '../components/Icon/OpenFolder'
 import Person from '../components/Icon/Person'
 import Head from '../components/Layout/Head'
 import LoadingView from '../components/Layout/LoadingView'
 import Navigation, { NavigationTab } from '../components/Layout/Navigation'
 import TokenBalanceCard from '../components/Token/TokenBalanceCard'
-import BudgetCard from '../components/Transparency/BudgetCard'
-import CoreUnitsSection from '../components/Transparency/CoreUnitsSection'
 import DaoVestingCard from '../components/Transparency/DaoVestingCard'
-import GrantList from '../components/Transparency/GrantList'
-import MembersSection from '../components/Transparency/MembersSection'
 import MonthlyTotal from '../components/Transparency/MonthlyTotal'
 import Sidebar from '../components/Transparency/Sidebar'
 import { DOCS_URL, JOIN_DISCORD_URL, OPEN_CALL_FOR_DELEGATES_LINK } from '../constants'
-import useCoreUnitsBadges from '../hooks/useCoreUnitsBadges'
 import useFormatMessage from '../hooks/useFormatMessage'
 import useTransparency from '../hooks/useTransparency'
-import { ProposalStatus } from '../types/proposals'
 import locations from '../utils/locations'
-import { formatBalance } from '../utils/proposal'
 import { aggregateBalances } from '../utils/transparency'
 
 import './transparency.css'
@@ -44,7 +35,6 @@ export default function TransparencyPage() {
   const t = useFormatMessage()
   const { data } = useTransparency()
   const balances = useMemo(() => (data && aggregateBalances(data.balances)) || [], [data])
-  const { coreUnitsBadges } = useCoreUnitsBadges()
 
   return (
     <>
@@ -123,44 +113,6 @@ export default function TransparencyPage() {
 
             <div className="TransparencyGrid">
               <Sidebar
-                title={t('page.transparency.funding.title')}
-                description={t('page.transparency.funding.description')}
-                buttons={[
-                  {
-                    href: locations.proposals(),
-                    icon: <OpenFolder size={20} />,
-                    isExternal: false,
-                    children: t('page.transparency.funding.view_all_button'),
-                  },
-                ]}
-              />
-
-              <div className="Transparency__Section">
-                <BudgetCard />
-                <Card className="Transparency__Card">
-                  <Card.Content>
-                    <Heading size="sm" weight="normal">
-                      {t('page.transparency.funding.total_title')}
-                    </Heading>
-                    <div className="Transparency__FundingProgress">
-                      <div className="Transparency__FundingProgressDescription">
-                        <Header size="huge" className="Transparency__FundingProgressTotal">
-                          {'$' + formatBalance(data.funding.total)}
-                          <Header size="small">USD</Header>
-                        </Header>
-                      </div>
-                    </div>
-                  </Card.Content>
-                  <GrantList
-                    status={ProposalStatus.Enacted}
-                    title={t('page.transparency.funding.proposals_funded_label') || ''}
-                  />
-                </Card>
-              </div>
-            </div>
-
-            <div className="TransparencyGrid">
-              <Sidebar
                 title={t('page.transparency.members.title')}
                 description={t('page.transparency.members.description')}
                 buttons={[
@@ -181,37 +133,7 @@ export default function TransparencyPage() {
                   },
                 ]}
               />
-
-              <div className="Transparency__Section">
-                <Card className="Transparency__Card">
-                  {data &&
-                    data.committees.map((team, index) => {
-                      return (
-                        <MembersSection
-                          key={[team.name.trim(), index].join('::')}
-                          title={team.name}
-                          description={team.description}
-                          members={team.members}
-                        />
-                      )
-                    })}
-                </Card>
-              </div>
             </div>
-
-            {coreUnitsBadges && (
-              <div className="TransparencyGrid">
-                <Sidebar
-                  title={t('page.transparency.core_units.title')}
-                  description={t('page.transparency.core_units.description')}
-                />
-                <div className="Transparency__Section">
-                  <Card className="Transparency__Card">
-                    <CoreUnitsSection coreUnitsBadges={coreUnitsBadges} />
-                  </Card>
-                </div>
-              </div>
-            )}
           </WiderContainer>
         )}
       </div>


### PR DESCRIPTION
Related issue #199 

In this Pr you can find:
-Remove grant program budget card from transparency page

Screenshots:
-Before
<img width="1452" height="663" alt="Captura de pantalla 2025-10-02 a la(s) 10 03 04 a  m" src="https://github.com/user-attachments/assets/7f038b7d-a3be-4712-bdc9-ee7169e81708" />

-After 
<img width="1470" height="600" alt="Captura de pantalla 2025-10-02 a la(s) 10 15 37 a  m" src="https://github.com/user-attachments/assets/22b91bfa-9717-4467-ab9a-54c92279f72e" />
