### PR TITLE
feat: support undo enacted proposals

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dcl/feature-flags": "^1.2.0",
+        "@dcl/hooks": "^1.0.0",
         "@dcl/schemas": "22.3.0",
         "@dcl/ui-env": "^2.0.0",
         "@hookform/resolvers": "^3.4.2",
@@ -25,6 +26,7 @@
         "dayjs": "^1.11.9",
         "dayjs-precise-range": "^1.0.1",
         "dcl-catalyst-client": "^21.7.0",
+        "decentraland-connect": "^11.1.0",
         "decentraland-crypto-middleware": "^1.2.0",
         "decentraland-dapps": "^26.11.0",
         "decentraland-ui": "^7.1.0",
@@ -3151,7 +3153,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/hooks/-/hooks-1.0.0.tgz",
       "integrity": "sha512-/CTeXN+7byqbuoO9u8oXWQMdmnSAxcPlEjuCgOqUdG6vW3vVk0CKkbTCzN7+hoUu62F/aQhpnNGE6OX7O9z0/A==",
-      "peer": true,
       "dependencies": {
         "@segment/analytics-next": "^1.79.0",
         "@sentry/browser": "^9.0.0",
@@ -20256,7 +20257,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-11.1.0.tgz",
       "integrity": "sha512-+VJAGM+XdRLCZRz5Ow7GvCzk9F6l9dE9a1VtSt81iQ/XY0ES7tMztxKDcU4b5XY7XBvvG12kLNG91xe1asxmRw==",
-      "peer": true,
       "dependencies": {
         "@dcl/schemas": "^22.1.0",
         "@magic-ext/oauth2": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "",
   "dependencies": {
     "@dcl/feature-flags": "^1.2.0",
+    "@dcl/hooks": "^1.0.0",
     "@dcl/schemas": "22.3.0",
     "@dcl/ui-env": "^2.0.0",
     "@hookform/resolvers": "^3.4.2",
@@ -52,6 +53,7 @@
     "dayjs": "^1.11.9",
     "dayjs-precise-range": "^1.0.1",
     "dcl-catalyst-client": "^21.7.0",
+    "decentraland-connect": "^11.1.0",
     "decentraland-crypto-middleware": "^1.2.0",
     "decentraland-dapps": "^26.11.0",
     "decentraland-ui": "^7.1.0",

--- a/src/components/Modal/UpdateProposalStatusModal/UpdateProposalStatusModal.tsx
+++ b/src/components/Modal/UpdateProposalStatusModal/UpdateProposalStatusModal.tsx
@@ -40,10 +40,17 @@ type Props = Omit<ModalProps, 'children'> & {
   proposalKey: string
 }
 
-const getPrimaryButtonTextKey = (status: ProposalStatus | null, isEdit: boolean) => {
+const isUndoingEnactment = (proposal: ProposalAttributes | null, status: ProposalStatus | null) =>
+  proposal?.status === ProposalStatus.Enacted && status === ProposalStatus.Passed
+
+const getPrimaryButtonTextKey = (status: ProposalStatus | null, isUndoEnactment: boolean) => {
+  if (isUndoEnactment) {
+    return 'modal.update_status_proposal.undo_enactment_accept'
+  }
+
   switch (status) {
     case ProposalStatus.Enacted:
-      return isEdit ? 'page.proposal_detail.edit_enacted_data' : 'page.proposal_detail.enact'
+      return 'page.proposal_detail.enact'
     case ProposalStatus.Passed:
       return 'page.proposal_detail.pass'
     case ProposalStatus.Rejected:
@@ -87,9 +94,11 @@ export function UpdateProposalStatusModal({
 
   const values = useWatch({ control })
 
-  const isProject = isProjectProposal(proposal?.type)
+  const isUndoEnactment = isUndoingEnactment(proposal, status)
+  const isProject = isProjectProposal(proposal?.type) && !isUndoEnactment
   const showAddButton = isProject && !!vesting_addresses && vesting_addresses.length > 0
   const hasValues = values.vestingAddresses && values.vestingAddresses.filter((value) => value.length > 0).length > 0
+  const modalStatus = isUndoEnactment ? ProposalStatus.Enacted : status
 
   useEffect(() => {
     setValue('vestingAddresses', defaultValues.vestingAddresses)
@@ -152,6 +161,7 @@ export function UpdateProposalStatusModal({
       setIsSubmitting(false)
       if (proposal) {
         queryClient.setQueryData([proposalKey], proposal)
+        queryClient.invalidateQueries([proposalKey])
         queryClient.invalidateQueries(['projectUpdates', proposal?.project_id])
       }
     },
@@ -179,8 +189,22 @@ export function UpdateProposalStatusModal({
       <Modal.Content>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="ProposalModal__Title">
-            <Header>{t('modal.update_status_proposal.title', { status })}</Header>
-            <Markdown size="lg">{t('modal.update_status_proposal.description', { status }) || ''}</Markdown>
+            <Header>
+              {t(
+                isUndoEnactment
+                  ? 'modal.update_status_proposal.undo_enactment_title'
+                  : 'modal.update_status_proposal.title',
+                { status: modalStatus }
+              )}
+            </Header>
+            <Markdown size="lg">
+              {t(
+                isUndoEnactment
+                  ? 'modal.update_status_proposal.undo_enactment_description'
+                  : 'modal.update_status_proposal.description',
+                { status: modalStatus }
+              ) || ''}
+            </Markdown>
           </div>
 
           {proposal && isProject && (
@@ -230,7 +254,7 @@ export function UpdateProposalStatusModal({
               disabled={isSubmitting || (isProject && !hasValues)}
               loading={loading && isSubmitting}
             >
-              {t(getPrimaryButtonTextKey(status, showAddButton))}
+              {t(getPrimaryButtonTextKey(status, isUndoEnactment))}
             </Button>
             <Button
               className="cancel"

--- a/src/components/Proposal/ProposalActions.tsx
+++ b/src/components/Proposal/ProposalActions.tsx
@@ -13,7 +13,12 @@ import useIsProposalOwner from '../../hooks/useIsProposalOwner'
 import { getProposalQueryKey } from '../../hooks/useProposal'
 import { ProposalAttributes, ProposalStatus } from '../../types/proposals'
 import locations from '../../utils/locations'
-import { isProposalDeletable, isProposalEnactable, proposalCanBePassedOrRejected } from '../../utils/proposal'
+import {
+  canUpdateProposalEnactment,
+  getProposalEnactmentStatusUpdate,
+  isProposalDeletable,
+  proposalCanBePassedOrRejected,
+} from '../../utils/proposal'
 import { DeleteProposalModal } from '../Modal/DeleteProposalModal/DeleteProposalModal'
 import { UpdateProposalStatusModal } from '../Modal/UpdateProposalStatusModal/UpdateProposalStatusModal'
 
@@ -40,8 +45,9 @@ export default function ProposalActions({ proposal }: Props) {
 
   const proposalStatus = proposal?.status
   const showDeleteButton = isOwner || isDAOCouncil
-  const showEnactButton = isDAOCouncil && isProposalEnactable(proposalStatus)
+  const showEnactButton = isDAOCouncil && canUpdateProposalEnactment(proposal)
   const showStatusUpdateButton = isDAOCouncil && proposalCanBePassedOrRejected(proposalStatus)
+  const enactmentStatusUpdate = getProposalEnactmentStatusUpdate(proposal)
 
   return (
     <>
@@ -57,11 +63,11 @@ export default function ProposalActions({ proposal }: Props) {
         </Button>
       )}
       {showEnactButton && (
-        <Button basic loading={updatingStatus} fluid onClick={() => setConfirmStatusUpdate(ProposalStatus.Enacted)}>
+        <Button basic loading={updatingStatus} fluid onClick={() => setConfirmStatusUpdate(enactmentStatusUpdate)}>
           {t(
             proposalStatus === ProposalStatus.Passed
               ? 'page.proposal_detail.enact'
-              : 'page.proposal_detail.edit_enacted_data'
+              : 'page.proposal_detail.undo_enactment'
           )}
         </Button>
       )}

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -544,6 +544,8 @@
     "update_status_proposal": {
       "title": "Confirm Proposal Enactment",
       "description": "Mark this proposal as **{status}**, add vesting contracts, or edit enactment data using this tool.",
+      "undo_enactment_title": "Undo Proposal Enactment",
+      "undo_enactment_description": "This proposal is currently **enacted**. Undoing enactment will set it back to **passed** and clear its enactment metadata.",
       "grant_vesting_addresses": "Vesting Contract Addresses",
       "add_vesting_contract": "Add vesting contract",
       "invalid_vesting_address": "Some address is invalid",
@@ -551,6 +553,7 @@
       "update_status_description_label": "Description",
       "update_status_description_placeholder": "Add any useful details for user",
       "accept": "Save",
+      "undo_enactment_accept": "Undo enactment",
       "reject": "Cancel",
       "update_error_label": "There was an error while trying to update the proposal, please try again."
     },
@@ -1300,7 +1303,7 @@
       "voting_ends": "Voting ends {countdown}",
       "proposal_status": "Proposal {status}",
       "enact": "Enact proposal",
-      "edit_enacted_data": "Edit enacted data",
+      "undo_enactment": "Undo enactment",
       "pass": "Pass proposal",
       "reject": "Reject proposal",
       "delete": "Delete proposal",

--- a/src/utils/proposal.test.ts
+++ b/src/utils/proposal.test.ts
@@ -1,0 +1,58 @@
+import { ProposalStatus, ProposalType } from '../types/proposals'
+
+import { canUpdateProposalEnactment, getProposalEnactmentStatusUpdate } from './proposal'
+
+const proposal = (type: ProposalType, status: ProposalStatus) => ({ type, status })
+
+describe('canUpdateProposalEnactment', () => {
+  it('prevents new enactments for passed poll and draft proposals', () => {
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Poll, ProposalStatus.Passed))).toBe(false)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Draft, ProposalStatus.Passed))).toBe(false)
+  })
+
+  it('allows undoing enactment for enacted poll and draft proposals', () => {
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Poll, ProposalStatus.Enacted))).toBe(true)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Draft, ProposalStatus.Enacted))).toBe(true)
+  })
+
+  it('allows governance proposals to be enacted and undone', () => {
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Governance, ProposalStatus.Passed))).toBe(true)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Governance, ProposalStatus.Enacted))).toBe(true)
+  })
+
+  it('allows non-poll/draft proposals to be enacted and undone', () => {
+    expect(canUpdateProposalEnactment(proposal(ProposalType.POI, ProposalStatus.Passed))).toBe(true)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.POI, ProposalStatus.Enacted))).toBe(true)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Grant, ProposalStatus.Passed))).toBe(true)
+    expect(canUpdateProposalEnactment(proposal(ProposalType.Bid, ProposalStatus.Enacted))).toBe(true)
+  })
+})
+
+describe('getProposalEnactmentStatusUpdate', () => {
+  it('sends passed when undoing enactment for any proposal type', () => {
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.Poll, ProposalStatus.Enacted))).toBe(
+      ProposalStatus.Passed
+    )
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.Draft, ProposalStatus.Enacted))).toBe(
+      ProposalStatus.Passed
+    )
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.Governance, ProposalStatus.Enacted))).toBe(
+      ProposalStatus.Passed
+    )
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.POI, ProposalStatus.Enacted))).toBe(
+      ProposalStatus.Passed
+    )
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.Grant, ProposalStatus.Enacted))).toBe(
+      ProposalStatus.Passed
+    )
+  })
+
+  it('sends enacted for new enactments', () => {
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.Governance, ProposalStatus.Passed))).toBe(
+      ProposalStatus.Enacted
+    )
+    expect(getProposalEnactmentStatusUpdate(proposal(ProposalType.POI, ProposalStatus.Passed))).toBe(
+      ProposalStatus.Enacted
+    )
+  })
+})

--- a/src/utils/proposal.ts
+++ b/src/utils/proposal.ts
@@ -245,6 +245,24 @@ export function isProposalEnactable(proposalStatus: ProposalStatus) {
   return proposalStatus === ProposalStatus.Passed || proposalStatus === ProposalStatus.Enacted
 }
 
+type ProposalEnactmentData = Pick<ProposalAttributes, 'status' | 'type'>
+
+export function canUpdateProposalEnactment(proposal: ProposalEnactmentData) {
+  if (!isProposalEnactable(proposal.status)) {
+    return false
+  }
+
+  if (proposal.status === ProposalStatus.Enacted) {
+    return true
+  }
+
+  return proposal.type !== ProposalType.Poll && proposal.type !== ProposalType.Draft
+}
+
+export function getProposalEnactmentStatusUpdate(proposal: ProposalEnactmentData) {
+  return proposal.status === ProposalStatus.Enacted ? ProposalStatus.Passed : ProposalStatus.Enacted
+}
+
 export function proposalCanBePassedOrRejected(proposalStatus?: ProposalStatus) {
   return proposalStatus === ProposalStatus.Finished
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig(({ command, mode }) => {
         },
       },
     },
+    optimizeDeps: {
+      exclude: ['thirdweb', '@base-org/account'],
+    },
     ...(command === 'build'
       ? {
           base: envVariables.VITE_BASE_URL,


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on the API change that allows enacted proposals to be reverted back to `passed`: https://github.com/decentraland/governance/pull/1931

## Purpose

This PR integrates support for undoing accidental proposal enactment from the UI.

Proposal enactment is stored in our database metadata, not in Snapshot. A DRAFT proposal was accidentally marked as `ENACTED`, which left it stuck because enacted DRAFT proposals cannot continue through the normal governance flow or be escalated to a GOVERNANCE proposal.

Affected draft proposal:
https://decentraland.org/governance/proposal/?id=917e38cf-c777-4d81-b4e2-bbc740d66599

## Server Support

The server now supports reverting an enacted proposal back to `passed` through the existing proposal status update endpoint:

`PATCH /api/proposals/:proposal`

Payload:

```json
{
  "status": "passed"
}
```

When the proposal is currently enacted, the server clears the enactment metadata:

- `enacted = false`
- `enacted_by = null`
- `enacted_description = null`
- `enacting_tx = null`

The server also blocks new enactments for `POLL` and `DRAFT` proposals. `GOVERNANCE` and other enactable proposal types can still be enacted.

This server behavior is implemented in the API repo and will be documented in its own PR.

## UI Integration

This PR keeps using the existing proposal status update modal and endpoint flow, but updates the behavior around enactment actions.

### Enactment actions

- `PASSED` proposals show `Enact proposal` for all proposal types except `POLL` and `DRAFT`.
- `PASSED` `POLL` and `DRAFT` proposals no longer show the enact action, preventing new accidental enactments from the UI.
- `ENACTED` proposals show `Undo enactment` for all proposal types, including `POLL`, `DRAFT`, `GOVERNANCE`, `POI`, grants, bids, and other enactable proposal types.
- The previous `Edit enacted data` action is removed.

### Undo enactment flow

When a proposal is already `ENACTED`, the modal explains that the proposal is currently enacted and that confirming will set it back to `PASSED` and clear enactment metadata.

On confirmation, the UI sends:

```json
{
  "status": "passed"
}
```

After a successful update, the proposal data is refreshed so the UI reflects the reverted status and cleared enactment metadata.

For project-style proposals, the undo flow does not show or require vesting address fields, keeping the undo payload focused on the status revert.

## Impact

- Prevents new accidental enactments for `POLL` and `DRAFT` proposals from the UI.
- Allows DAO Council to recover any already enacted proposal by setting it back to `PASSED`.
- Preserves the enactment flow for `GOVERNANCE` and other enactable proposal types, such as `POI`.
- Removes the old edit-enactment metadata path in favor of two explicit actions: `Enact proposal` and `Undo enactment`.
- Reuses the existing status update endpoint and modal flow instead of introducing a separate undo endpoint or UI path.

## Verification

- Added tests for the proposal enactment action rules.
- Verified TypeScript compilation.
- Verified production build.
- Smoke-tested the local UI against the running backend.
