### PR TITLE
Fix broken docs links + add warning-only link checker

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,19 @@
+name: Link Check
+
+# Verifies that product-owned documentation/external links still resolve.
+# This is informational only: it reports broken links as warning annotations
+# and never fails the build.
+
+on: [push, pull_request]
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: 24
+      - name: Check links (warning only)
+        run: node scripts/check-links.js

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -10,7 +10,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
       - name: Use Node.js 24.x
         uses: actions/setup-node@v4.0.1
         with:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "NODE_OPTIONS='--max-old-space-size=6144' tsc && vite build",
     "preview": "vite preview",
     "test": "jest",
+    "check-links": "node scripts/check-links.js",
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,160 @@
+/* eslint-disable */
+/**
+ * Link checker (warning-only).
+ *
+ * Scans product-owned source files for http(s) URLs and verifies each one
+ * resolves (HTTP status < 400). Broken links are reported as GitHub Actions
+ * warning annotations and printed in a summary, but the script ALWAYS exits 0
+ * so it never fails the build.
+ *
+ * Delegate-supplied links (src/utils/delegates/candidates.json) are skipped on
+ * purpose: keeping those up to date is the responsibility of each delegate.
+ *
+ * Usage: node scripts/check-links.js
+ */
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = path.resolve(__dirname, '..')
+const SRC = path.join(ROOT, 'src')
+
+// Directories/files to scan for product-owned links.
+const SCAN_TARGETS = ['intl', 'constants', 'components', 'pages', 'hooks', 'utils']
+
+// Files/paths we never want to check.
+const EXCLUDE_PATHS = [
+  // Delegates maintain their own profile links.
+  path.join('utils', 'delegates', 'candidates.json'),
+]
+
+// Skip test fixtures, stories and mocks.
+const EXCLUDE_FILE_PATTERN = /(\.test\.|\.stories\.|\.spec\.|__mocks__|__tests__)/
+
+// Hosts/URLs that are placeholders or known-unverifiable (test fixtures, etc.).
+const IGNORE_URL_PATTERN =
+  /(localhost|127\.0\.0\.1|0\.0\.0\.0|example\.com|valid-image\.com|invalid-image\.com|\{|\}|\$\{)/
+
+// API/SDK base URLs that are only ever used with a path appended, so they
+// (correctly) return 4xx at their root. Checking them produces false positives.
+const IGNORE_EXACT = new Set([
+  'https://api.decentraland.org',
+  'https://cdn.segment.com/analytics.js/v1/',
+])
+
+const URL_REGEX = /https?:\/\/[^\s"'`)<>\]\\]+/g
+const SCANNED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.json', '.md'])
+
+const TIMEOUT_MS = 15000
+const CONCURRENCY = 10
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; governance-ui-link-checker/1.0; +https://governance.decentraland.org)'
+
+function walk(dir) {
+  const out = []
+  if (!fs.existsSync(dir)) return out
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(full))
+    } else if (SCANNED_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function isExcluded(file) {
+  const rel = path.relative(SRC, file)
+  if (EXCLUDE_FILE_PATTERN.test(rel)) return true
+  return EXCLUDE_PATHS.some((p) => rel === p || rel.startsWith(p + path.sep))
+}
+
+function cleanUrl(raw) {
+  // Trim trailing punctuation commonly captured by the regex.
+  return raw.replace(/[.,;:]+$/, '')
+}
+
+function collectLinks() {
+  const links = new Map() // url -> Set(relative file paths)
+  const files = SCAN_TARGETS.flatMap((t) => walk(path.join(SRC, t)))
+  for (const file of files) {
+    if (isExcluded(file)) continue
+    const content = fs.readFileSync(file, 'utf8')
+    const matches = content.match(URL_REGEX)
+    if (!matches) continue
+    for (const m of matches) {
+      const url = cleanUrl(m)
+      if (IGNORE_URL_PATTERN.test(url) || IGNORE_EXACT.has(url)) continue
+      if (!links.has(url)) links.set(url, new Set())
+      links.get(url).add(path.relative(ROOT, file))
+    }
+  }
+  return links
+}
+
+async function checkUrl(url) {
+  const attempt = async (method) => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    try {
+      const res = await fetch(url, {
+        method,
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { 'User-Agent': USER_AGENT, Accept: '*/*' },
+      })
+      return res.status
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+  try {
+    // Prefer a lightweight HEAD; fall back to GET when HEAD is unsupported/blocked.
+    let status = await attempt('HEAD')
+    if (status >= 400 || status === 0) status = await attempt('GET')
+    return { url, status, ok: status > 0 && status < 400 }
+  } catch (err) {
+    return { url, status: 0, ok: false, error: err.code || err.name || String(err) }
+  }
+}
+
+async function run() {
+  const links = collectLinks()
+  const urls = [...links.keys()].sort()
+  console.log(`Checking ${urls.length} product-owned link(s)...\n`)
+
+  const results = []
+  for (let i = 0; i < urls.length; i += CONCURRENCY) {
+    const batch = urls.slice(i, i + CONCURRENCY)
+    results.push(...(await Promise.all(batch.map(checkUrl))))
+  }
+
+  const broken = results.filter((r) => !r.ok)
+
+  for (const r of results.sort((a, b) => a.url.localeCompare(b.url))) {
+    console.log(`${r.ok ? 'OK  ' : 'WARN'} ${String(r.status || r.error).padEnd(6)} ${r.url}`)
+  }
+
+  if (broken.length > 0) {
+    console.log(`\n::group::⚠️ ${broken.length} broken link(s) found`)
+    for (const r of broken) {
+      const where = [...links.get(r.url)].join(', ')
+      const detail = r.status ? `HTTP ${r.status}` : r.error || 'unreachable'
+      // GitHub Actions warning annotation (does not fail the build).
+      console.log(`::warning title=Broken link::${r.url} (${detail}) — referenced in: ${where}`)
+    }
+    console.log('::endgroup::')
+    console.log(`\n⚠️  ${broken.length}/${urls.length} link(s) need attention (warning only).`)
+  } else {
+    console.log(`\n✅ All ${urls.length} links resolved.`)
+  }
+
+  // Always succeed: this is a warning, not a gate.
+  process.exit(0)
+}
+
+run().catch((err) => {
+  // Even on unexpected errors, do not break the build.
+  console.warn('::warning title=Link checker error::' + (err && err.stack ? err.stack : err))
+  process.exit(0)
+})

--- a/src/components/Projects/Current/ProjectsBanner.tsx
+++ b/src/components/Projects/Current/ProjectsBanner.tsx
@@ -37,7 +37,7 @@ export default function ProjectsBanner() {
       {
         title: t('page.grants.banner.faq_title'),
         description: t('page.grants.banner.faq_description'),
-        url: 'https://docs.decentraland.org/player/general/dao/overview/grants-faq/',
+        url: 'https://docs.decentraland.org/dao/dao/the-dao-fund',
       },
     ],
     [t]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,7 +6,7 @@ import Candidates from '../utils/delegates/candidates.json'
 export const DISCOURSE_USER = config.get('DISCOURSE_USER')
 export const DISCOURSE_API = config.get('DISCOURSE_API')
 export const GOVERNANCE_URL = import.meta.env.VITE_GOVERNANCE_URL || config.get('GOVERNANCE_URL')
-export const DOCS_URL = 'https://docs.decentraland.org/decentraland/what-is-the-dao/'
+export const DOCS_URL = 'https://docs.decentraland.org/dao/dao/what-is-the-dao'
 export const FORUM_URL = DISCOURSE_API
 export const GOVERNANCE_API = import.meta.env.VITE_GOVERNANCE_API || config.get('GOVERNANCE_API')
 export const DAO_DISCORD_URL = 'https://dcl.gg/dao-discord'

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -957,7 +957,7 @@
       },
       "open_proposals": {
         "title": "Open Proposals",
-        "description": "Proposals are created by the community and work as the consensus mechanism used to outline policies and changes to the Decentraland ecosystem. Learn more about them [here](https://docs.decentraland.org/decentraland/what-can-you-do-with-the-dao/).",
+        "description": "Proposals are created by the community and work as the consensus mechanism used to outline policies and changes to the Decentraland ecosystem. Learn more about them [here](https://docs.decentraland.org/dao/dao/what-can-you-do-with-the-dao).",
         "loading": "Fetching open proposals...",
         "ending_soon": "Ending soon",
         "by_user": "By ",
@@ -982,7 +982,7 @@
       },
       "active_community_grants": {
         "title": "Active Community Grants",
-        "description": "Grants are the mechanism that the DAO uses to fund community projects that add value to the Decentraland ecosystem with our Treasury. Read more about grants [here](https://docs.decentraland.org/decentraland/community-grants/).",
+        "description": "Grants are the mechanism that the DAO uses to fund community projects that add value to the Decentraland ecosystem with our Treasury. Read more about grants [here](https://docs.decentraland.org/dao/dao/the-dao-fund).",
         "view_all_grants": "View all Grants",
         "fetching": "Fetching active Community Grants..."
       },
@@ -1675,12 +1675,12 @@
       },
       "delegation": {
         "title": "Delegated VP to",
-        "helper": "This is the DAO member this user delegated their VP to. Learn more about VP delegation [here](https://docs.decentraland.org/player/general/dao/overview/how-does-the-dao-work/)",
+        "helper": "This is the DAO member this user delegated their VP to. Learn more about VP delegation [here](https://docs.decentraland.org/dao/dao/how-does-the-dao-work)",
         "change_delegation": "Change Delegation"
       },
       "delegators": {
         "title": "VP Delegators",
-        "helper": "These are all the DAO members that delegated their VP to this user. Learn more about VP Delegation [here](https://docs.decentraland.org/player/general/dao/overview/how-does-the-dao-work/)",
+        "helper": "These are all the DAO members that delegated their VP to this user. Learn more about VP Delegation [here](https://docs.decentraland.org/dao/dao/how-does-the-dao-work)",
         "delegated": "Delegated {vp} VP",
         "delegate_action": "Delegate them your VP",
         "button": "Show all delegators"
@@ -1988,7 +1988,7 @@
       "category_selection": {
         "description": "Choose a category that best suits your project",
         "suspended_description": "The budget allocation for the following Grant categories has been suspended for the time being as a result of a binding community decision on [this proposal](https://decentraland.org/governance/proposal/?id=a89f79f1-7171-4982-8ca1-5a21b5872373)",
-        "documentation": "Not sure which one to choose? Find out more about our Categories on our [Grants Documentation](https://docs.decentraland.org/player/general/dao/overview/grants-program/#grant-categories-and-requirements)"
+        "documentation": "Not sure which one to choose? Find out more about our Categories on our [Grants Documentation](https://docs.decentraland.org/dao/dao/the-dao-fund)"
       },
       "modal_actions": {
         "submit": "SUBMIT",
@@ -2025,7 +2025,7 @@
         "title_label": "Title",
         "title_detail": "Provide a title that is concise and descriptive for your grant request. This title will appear as the header of your proposal’s detail page on the Governance dApp, our Snapshot space, and the Forum thread of your Proposal.",
         "title_placeholder": "Enter a descriptive title for your grant proposal here.",
-        "description": "Decentraland Grants allow the DAO’s MANA to fund the creation of features or content for the Decentraland platform. Either individuals or teams may apply within one of five categories, and there are six levels of funding for each category. Before submitting your grant proposal, please review the [Grants Framework](https://docs.decentraland.org/decentraland/community-grants/) here.\n\nAside from the requirements listed in the Grants Framework and Decentraland’s [Content Policy](https://decentraland.org/content), [Terms of Use](https://decentraland.org/terms), and [Code of Ethics](https://decentraland.org/ethics), there are no constraints on the content or features that may be funded.",
+        "description": "Decentraland Grants allow the DAO’s MANA to fund the creation of features or content for the Decentraland platform. Either individuals or teams may apply within one of five categories, and there are six levels of funding for each category. Before submitting your grant proposal, please review the [Grants Framework](https://docs.decentraland.org/dao/dao/the-dao-fund) here.\n\nAside from the requirements listed in the Grants Framework and Decentraland’s [Content Policy](https://decentraland.org/content), [Terms of Use](https://decentraland.org/terms), and [Code of Ethics](https://decentraland.org/ethics), there are no constraints on the content or features that may be funded.",
         "description_label": "Description",
         "description_detail": "Allows you to elaborate on why your project should receive funding, the problems that your project will solve, or the benefits it will bring to the Decentraland platform.",
         "abstract_label": "Abstract",
@@ -2176,7 +2176,7 @@
       "final_consent": {
         "title": "Final Consent",
         "subtitle": "Review and check the following",
-        "grants_framework_label": "I’ve read and understood the [Grants Framework](https://docs.decentraland.org/decentraland/community-grants/)",
+        "grants_framework_label": "I’ve read and understood the [Grants Framework](https://docs.decentraland.org/dao/dao/the-dao-fund)",
         "content_policy_label": "I’ve read and understood Decentraland’s [Content Policy](https://decentraland.org/content)",
         "terms_of_use_label": "I’ve read Decentraland’s [Terms of Use](https://decentraland.org/terms) and agree with them",
         "code_of_ethics_label": "I’ve read Decentraland’s [Code of Ethics](https://decentraland.org/ethics) and hereby commit to honoring it",
@@ -2200,7 +2200,7 @@
     },
     "submit_linked_wearables": {
       "title": "Linked Wearables Registry",
-      "description": "Linked Wearables are a way to represent NFTs as Wearables in Decentraland. Third parties need to submit a proposal to be approved by the DAO in order to access the tool in the [Builder](https://builder.decentraland.org/) and get slots to submit the 3D models. By using this tool, you will be able to submit [NFTs as Wearables](https://governance.decentraland.org/proposal/?id=14e76cc0-2bc7-11ec-ac84-77607720a240) to be curated and made available for your NFT holders inside Decentraland.\n\nNote that after being approved, you will need to create an API with the endpoints described in this [Document](https://github.com/decentraland/adr/blob/main/docs/ADR-42-third-party-assets-integration.md#third-party-resolver).",
+      "description": "Linked Wearables are a way to represent NFTs as Wearables in Decentraland. Third parties need to submit a proposal to be approved by the DAO in order to access the tool in the [Builder](https://builder.decentraland.org/) and get slots to submit the 3D models. By using this tool, you will be able to submit [NFTs as Wearables](https://governance.decentraland.org/proposal/?id=14e76cc0-2bc7-11ec-ac84-77607720a240) to be curated and made available for your NFT holders inside Decentraland.\n\nNote that after being approved, you will need to create an API with the endpoints described in this [Document](https://github.com/decentraland/adr/blob/main/content/ADR-42-third-party-assets-integration.md#third-party-resolver).",
       "name_label": "Name",
       "name_detail": "Please enter the name that represents your Project, Company, or Community as a whole",
       "name_placeholder": "Enter the name here",

--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -29,7 +29,7 @@ import './transparency.css'
 const DASHBOARD_URL =
   'https://datastudio.google.com/u/3/reporting/fca13118-c18d-4e68-9582-ad46d2dd5ce9/page/p_n06szvxkrc'
 const DATA_SHEET_URL = 'https://docs.google.com/spreadsheets/d/1FoV7TdMTVnqVOZoV4bvVdHWkeu4sMH5JEhp8L0Shjlo/edit'
-const ABOUT_DAO_URL = 'https://docs.decentraland.org/decentraland/how-does-the-dao-work/'
+const ABOUT_DAO_URL = 'https://docs.decentraland.org/dao/dao/how-does-the-dao-work'
 const WEARABLE_CURATORS_URL = 'https://forum.decentraland.org/t/wearables-curation-committee-member-nominations/2047'
 
 export default function TransparencyPage() {


### PR DESCRIPTION
## Summary

Two related changes from a fresh-eyes QA pass on the governance dApp:

1. **Fix broken documentation links.** `docs.decentraland.org` reorganized to a `/dao/dao/*` structure and the ADR repo moved `docs/` → `content/`, leaving several in-product help links returning 404 — including the "Grants Framework" link used on the grant-submission consent checkbox.
2. **Add a warning-only CI link-checker** so this class of rot is caught automatically going forward.

## Link fixes (10 links, 4 files)

- `src/constants/index.ts` — `DOCS_URL` → `/dao/dao/what-is-the-dao`
- `src/pages/transparency.tsx` — `ABOUT_DAO_URL` → `/dao/dao/how-does-the-dao-work`
- `src/components/Projects/Current/ProjectsBanner.tsx` — FAQ link → `/dao/dao/the-dao-fund`
- `src/intl/en.json` (7 links) — DAO-overview links repointed to their exact new pages; ADR-42 → `/content/...`

⚠️ **For a content owner to confirm:** the docs no longer have dedicated "Grants Framework" / "grant categories" pages — that content was consolidated into `/dao/dao/the-dao-fund`, so the grant-related links now point there. A working, relevant page beats a 404, but the DAO may want a richer canonical grants doc.

## Link checker

- `scripts/check-links.js` — no-dependency Node script. Scans product-owned source (`intl`, `constants`, `components`, `pages`, `hooks`, `utils`) for http(s) links and reports unreachable ones as GitHub Actions `::warning::` annotations. **Always exits 0 — never fails the build.** Skips `candidates.json` (delegate-maintained) and test/story fixtures; ignores API base-URLs that 404 at root.
- `.github/workflows/link-check.yaml` — runs on push/PR (Node 24).
- `npm run check-links` — local runs.

## Verification

- `en.json` validated as parseable JSON.
- Checker run: 42 product links checked, all fixed docs links return 200, script exits 0.
- Only remaining warning is a genuinely-down third-party catalyst (`peer.decentral.io`, HTTP 521) — out of scope, and exactly what the warning is meant to surface without blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)