### PR TITLE
Warn on disputed treasury wallets in transparency page

### DIFF
--- a/src/components/Token/TokensPerWalletPopup.css
+++ b/src/components/Token/TokensPerWalletPopup.css
@@ -15,19 +15,56 @@
   flex-direction: row;
 }
 
+.TokensPerWalletPopup .TokensPerWalletPopup__Item {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.TokensPerWalletPopup .TokensPerWalletPopup__Item:last-of-type {
+  margin-bottom: 0;
+}
+
 .TokensPerWalletPopup .TokensPerWalletPopup__Row {
   display: flex;
   flex-grow: 1;
   align-content: space-between;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
   padding: 5px;
   border-radius: 10px;
 }
 
-.TokensPerWalletPopup .TokensPerWalletPopup__Row:last-of-type {
-  margin-bottom: 0;
+.TokensPerWalletPopup .TokensPerWalletPopup__WalletName {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.TokensPerWalletPopup .TokensPerWalletPopup__WarningIcon {
+  flex-shrink: 0;
+}
+
+.TokensPerWalletPopup .TokensPerWalletPopup__Warning {
+  display: flex;
+  align-items: flex-start;
+  margin: 4px 5px 0;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(255, 176, 63, 0.12);
+}
+
+.TokensPerWalletPopup .TokensPerWalletPopup__WarningText {
+  color: var(--white-900);
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.TokensPerWalletPopup .TokensPerWalletPopup__Warning a {
+  color: var(--blue-600) !important;
+  font-weight: var(--weight-semi-bold);
+  white-space: nowrap;
 }
 
 .TokensPerWalletPopup .TokensPerWalletPopup__Block {

--- a/src/components/Token/TokensPerWalletPopup.tsx
+++ b/src/components/Token/TokensPerWalletPopup.tsx
@@ -2,12 +2,15 @@ import { Card } from 'decentraland-ui/dist/components/Card/Card'
 import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Popup } from 'decentraland-ui/dist/components/Popup/Popup'
 
+import { COMMITTEE_DEPRECATION_PROPOSAL_ID } from '../../constants'
 import useFormatMessage from '../../hooks/useFormatMessage'
-import { TokenInWallet } from '../../types/transparency'
+import { TokenInWallet, WalletStatus } from '../../types/transparency'
+import locations from '../../utils/locations'
 import { blockExplorerLink } from '../../utils/transparency'
 import Link from '../Common/Typography/Link'
 import Text from '../Common/Typography/Text'
 import Info from '../Icon/Info'
+import WarningTriangle from '../Icon/WarningTriangle'
 
 import './TokensPerWalletPopup.css'
 
@@ -27,26 +30,38 @@ export default function TokensPerWalletPopup({ tokensPerWallet, open, onClose }:
           if (tokenInWallet.amount == BigInt(0)) return
 
           const explorerLink = blockExplorerLink(tokenInWallet)
+          const isDisputed = tokenInWallet.status === WalletStatus.Disputed
           return (
-            <Link
-              className="TokensPerWalletPopup__Row"
-              key={[tokenInWallet.name, '_popup', index].join('::')}
-              href={explorerLink.link}
-            >
-              <div className="TokensPerWalletPopup__Block">
-                <Header>{tokenInWallet.name}</Header>
-                <Header sub>{tokenInWallet.network} Network</Header>
-              </div>
-              <div className="TokensPerWalletPopup__Block TokensPerWalletPopup__RightBlock">
-                <div className={'TokensPerWalletPopup__Balance'}>
-                  <Header>{t('general.number', { value: tokenInWallet.amount })}</Header>
-                  <Text className="TokensPerWalletPopup__Symbol">{tokenInWallet.symbol}</Text>
+            <div className="TokensPerWalletPopup__Item" key={[tokenInWallet.name, '_popup', index].join('::')}>
+              <Link className="TokensPerWalletPopup__Row" href={explorerLink.link}>
+                <div className="TokensPerWalletPopup__Block">
+                  <div className="TokensPerWalletPopup__WalletName">
+                    {isDisputed && <WarningTriangle className="TokensPerWalletPopup__WarningIcon" />}
+                    <Header>{tokenInWallet.name}</Header>
+                  </div>
+                  <Header sub>{tokenInWallet.network} Network</Header>
                 </div>
-                <Header sub className="TokensPerWalletPopup__Link">
-                  {t('page.transparency.mission.audit', { service_name: explorerLink.name })}
-                </Header>
-              </div>
-            </Link>
+                <div className="TokensPerWalletPopup__Block TokensPerWalletPopup__RightBlock">
+                  <div className={'TokensPerWalletPopup__Balance'}>
+                    <Header>{t('general.number', { value: tokenInWallet.amount })}</Header>
+                    <Text className="TokensPerWalletPopup__Symbol">{tokenInWallet.symbol}</Text>
+                  </div>
+                  <Header sub className="TokensPerWalletPopup__Link">
+                    {t('page.transparency.mission.audit', { service_name: explorerLink.name })}
+                  </Header>
+                </div>
+              </Link>
+              {isDisputed && (
+                <div className="TokensPerWalletPopup__Warning">
+                  <Text className="TokensPerWalletPopup__WarningText">
+                    {t('page.transparency.mission.disputed_wallet_warning')}{' '}
+                    <Link href={locations.proposal(COMMITTEE_DEPRECATION_PROPOSAL_ID)}>
+                      {t('page.transparency.mission.disputed_wallet_learn_more')}
+                    </Link>
+                  </Text>
+                </div>
+              )}
+            </div>
           )
         })}
       </Card.Content>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,9 @@ export const FORUM_URL = DISCOURSE_API
 export const GOVERNANCE_API = import.meta.env.VITE_GOVERNANCE_API || config.get('GOVERNANCE_API')
 export const DAO_DISCORD_URL = 'https://dcl.gg/dao-discord'
 export const OPEN_CALL_FOR_DELEGATES_LINK = 'https://forum.decentraland.org/t/open-call-for-delegates-apply-now/5840'
+// Proposal that deprecated the DAO Committee and created the Council Operational
+// Multisig. Linked from the transparency page's disputed-wallet warning.
+export const COMMITTEE_DEPRECATION_PROPOSAL_ID = 'bb2b8234-42aa-4ca2-a049-3c7355d4caa4'
 export const CANDIDATE_ADDRESSES = Candidates.map((delegate) => delegate.address)
 export const SEGMENT_KEY = config.get('SEGMENT_KEY') || ''
 export const LOCAL_ENV_VAR = config.get('GATSBY_LOCAL_ENV_VAR') || ''

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1741,6 +1741,8 @@
         "dashboard_button": "Transparency Dashboard",
         "data_source_button": "DCL Data Source",
         "audit": "Audit on {service_name}",
+        "disputed_wallet_warning": "Funds withheld from the DAO. The former DAO Committee retains control of these wallets and has not returned the assets to the DAO.",
+        "disputed_wallet_learn_more": "Learn more",
         "monthly_income": "Last 30 Days Income",
         "monthly_expenses": "Last 30 Days Expenses",
         "diff_label": "vs previous 30 days",

--- a/src/types/transparency.ts
+++ b/src/types/transparency.ts
@@ -1,3 +1,11 @@
+export enum WalletStatus {
+  // Under DAO control; funds are available to the DAO.
+  Active = 'active',
+  // Controlled by a third party (e.g. the former DAO Committee); funds are
+  // NOT currently available to the DAO.
+  Disputed = 'disputed',
+}
+
 export type TokenInWallet = {
   symbol: string
   contractAddress: string
@@ -8,6 +16,9 @@ export type TokenInWallet = {
   address: string
   timestamp: Date
   rate: number
+  // Optional for backward compatibility with balances.json produced before the
+  // transparency pipeline started emitting wallet status.
+  status?: WalletStatus
 }
 
 export type TokenTotal = {


### PR DESCRIPTION
## Summary

Surfaces wallet status on the transparency page: warns that the former DAO Committee multisigs' funds are not under DAO control, and lets the new DAO Council Operational Multisig appear automatically.

Refs proposal [DAO Committee Deprecation & Replacement](https://decentraland.org/governance/proposal/?id=bb2b8234-42aa-4ca2-a049-3c7355d4caa4).

## ⚠️ Depends on the transparency pipeline PR — merge that first

**Requires:** Decentraland-DAO/transparency#121 (adds `status` + the Council multisig to `balances.json`).

This PR is **backward-compatible**: `status` is optional, so nothing changes until the pipeline publishes the updated `balances.json`. Merging this before #121 is safe but inert (no warnings/new wallet shown until the data carries `status`).

## Changes

- **`types/transparency.ts`** — optional `status` (`active` | `disputed`) on `TokenInWallet`; flows straight from `balances.json` (the client casts the response directly).
- **`TokensPerWalletPopup.tsx`** + CSS — disputed wallets get a ⚠ icon next to the name and a warning note:
  > Funds withheld from the DAO. The former DAO Committee retains control of these wallets and has not returned the assets to the DAO. [Learn more →]

  "Learn more" links to the deprecation proposal.
- **`constants`** — `COMMITTEE_DEPRECATION_PROPOSAL_ID`.
- **`en.json`** — warning copy.

## Product decisions baked in

- **Totals unchanged**: disputed funds remain in the per-token totals and are flagged in the popup (not excluded).
- **Prominence**: popup badge only (no page-level banner).
- The **new Council multisig** needs no UI work — it renders automatically once it's in the published balances data.

## Testing notes

Couldn't run `tsc`/tests locally (no `node_modules` in the worktree); CI will typecheck. Change is small and type-checked by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)